### PR TITLE
Graceful shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btnify"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "Hosts a website with buttons for you so you can focus on what matters!"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ axum = "0.6.20"
 hyper = "0.14.27"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
+tokio = { version = "1.34.0", features = ["sync", "macros", "signal"] }
 
 [dev-dependencies]
 html-to-string-macro = "0.2.5"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ let buttons = vec![count_button, plus_button, end_button];
 
 let (tx, rx) = oneshot::channel();
 
-let shutdown_config = ShutdownConfig::new(Some(rx), Box::new(server_end));
+let shutdown_config = ShutdownConfig::new(Some(rx), Some(Box::new(server_end)));
 
 bind_server(&"0.0.0.0:3000".parse().unwrap(), buttons, Counter::new(tx), None);
 // uncomment to actually run the server:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run `cargo add btnify`
 
 or
 
-Add `btnify = "1.0.0"` to your `Cargo.toml`
+Add `btnify = "2.0.0"` to your `Cargo.toml`
 
 ## How to use
 
@@ -41,12 +41,13 @@ Add `btnify = "1.0.0"` to your `Cargo.toml`
 Hello World
 
 ```rust
-use btnify::button::{Button, ButtonResponse, ExtraResponse};
+use btnify::button::{Button, ButtonResponse};
 
 fn greet_handler() -> ButtonResponse {
     ButtonResponse::from("hello world!")
 }
 
+// this button doesn't use any state so we will mark the state generic as unit
 let greet_button: Button<()> = Button::create_basic_button("Greet!", Box::new(greet_handler));
 ```
 
@@ -76,19 +77,34 @@ Counter App
 
 ```rust
 use std::sync::Mutex;
+use tokio::sync::oneshot;
 use btnify::bind_server;
-use btnify::button::{Button, ButtonResponse, ExtraResponse};
+use btnify::ShutdownConfig;
+use btnify::button::{Button, ButtonResponse};
 
 struct Counter {
-    // must use mutex to be thread-safe
-    count: Mutex<i32>
+    // must use Mutex for interior mutability
+    count: Mutex<i32>,
+    end_server_tx: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl Counter {
-    fn new() -> Counter {
+    fn new(tx: oneshot::Sender<()>) -> Counter {
         Counter {
-            count: Mutex::new(0)
+            count: Mutex::new(0),
+            end_server_tx: Mutex::new(Some(tx)),
         }
+    }
+
+    fn end_server(&self) {
+        // Acquire the Mutex to modify
+        let mut tx = self.end_server_tx.lock().unwrap();
+
+        // Take the sender
+        let tx = tx.take().unwrap();
+
+        // Send the signal to end the server
+        tx.send(()).unwrap();
     }
 }
 
@@ -97,11 +113,11 @@ fn count_handler(state: &Counter) -> ButtonResponse {
     format!("The count is: {count}").into()
 }
 
-fn plus_handler(counter_struct: &Counter, responses: Vec<Option<String>>) -> ButtonResponse {
+fn plus_handler(state: &Counter, responses: Vec<Option<String>>) -> ButtonResponse {
     match &responses[0] {
         Some(response_str) => {
             if let Ok(amount) = response_str.parse::<i32>() {
-                let mut count = counter_struct.count.lock().unwrap();
+                let mut count = state.count.lock().unwrap();
                 *count += amount;
                 format!("The count now is: {}", *count).into()
             } else {
@@ -112,6 +128,15 @@ fn plus_handler(counter_struct: &Counter, responses: Vec<Option<String>>) -> But
     }
 }
 
+fn end_button_handler(state: &Counter) -> ButtonResponse {
+    state.end_server();
+    "Server is ending. Goodbye!".into()
+}
+
+fn server_end(state: &Counter) {
+    println!("goodbye world. ;(");
+}
+
 let count_button = Button::create_button_with_state("Counter", Box::new(count_handler));
 
 let plus_button = Button::create_button_with_state_and_prompts(
@@ -120,10 +145,16 @@ let plus_button = Button::create_button_with_state_and_prompts(
     vec!["How much do you want to add?".to_string()]
 );
 
-let buttons = [count_button, plus_button];
+let end_button = Button::create_button_with_state("End Server", Box::new(end_button_handler));
 
-// uncomment to run server on localhost:3000
-// bind_server(&"0.0.0.0:3000".parse().unwrap(), buttons, Counter::new())
+let buttons = vec![count_button, plus_button, end_button];
+
+let (tx, rx) = oneshot::channel();
+
+let shutdown_config = ShutdownConfig::new(Some(rx), Box::new(server_end));
+
+bind_server(&"0.0.0.0:3000".parse().unwrap(), buttons, Counter::new(tx), None);
+// uncomment to actually run the server:
 //    .await
 //    .unwrap();
 ```


### PR DESCRIPTION
Main addition is the `ShutdownConfig` struct. This update allows users to listen for when the server is shutting down for any reason (including ctrl+c) and allows users to shut down the server themselves. The counting app example shows how it works 👍 